### PR TITLE
Add reducer enhancer for custom action handling

### DIFF
--- a/src/action-reducer.js
+++ b/src/action-reducer.js
@@ -15,7 +15,7 @@ export const SET_DEFAULT_UI_STATE = '@@redux-ui/SET_DEFAULT_UI_STATE';
 
 const defaultState = new Map();
 
-export default function(state = defaultState, action) {
+export default function reducer(state = defaultState, action) {
   let key = action.payload && (action.payload.key || []);
 
   if (!Array.isArray(key)) {
@@ -54,6 +54,14 @@ export default function(state = defaultState, action) {
       return state.deleteIn(key);
   }
 
+  return state;
+}
+
+export const reducerEnhancer = (customReducer) => (state, action) => {
+  state = reducer(state, action);
+  if (typeof customReducer === 'function') {
+    state = customReducer(state, action);
+  }
   return state;
 }
 

--- a/test/action-reducer/reducer.js
+++ b/test/action-reducer/reducer.js
@@ -1,0 +1,67 @@
+'use strict';
+
+import {
+  reducer,
+  reducerEnhancer,
+  UPDATE_UI_STATE
+} from '../../src/action-reducer.js';
+
+import { assert } from 'chai';
+import { is, Map } from 'immutable';
+import { Provider } from 'react-redux';
+import { createStore, combineReducers } from 'redux';
+
+const customReducer = (state, action) => {
+  if (action.type === 'CUSTOM_ACTION_TYPE') {
+    return state.set('isHooked', true);
+  }
+  return state;
+}
+const enhancedReducer = reducerEnhancer(customReducer);
+
+describe('reducerEnhancer', () => {
+  let enhancedStore;
+  
+  beforeEach( () => {
+    enhancedStore = createStore(combineReducers({ ui: enhancedReducer }));
+  });
+
+  it('delegates to the default reducer', () => {
+    assert.equal(enhancedStore.getState().ui, new Map());
+
+    enhancedStore.dispatch({
+      type: UPDATE_UI_STATE,
+      payload: {
+        key: 'a',
+        name: 'foo',
+        value: 'bar'
+      }
+    });
+
+    assert.isTrue(
+      is(
+        enhancedStore.getState().ui,
+        new Map({
+          a: new Map({ foo: 'bar' })
+        })
+      )
+    );
+  });
+
+  it('intercepts custom actions', () => {
+    assert.equal(enhancedStore.getState().ui, new Map());
+    enhancedStore.dispatch({
+      type: 'CUSTOM_ACTION_TYPE',
+      payload: {
+        foo: 'bar'
+      }
+    });
+    assert.isTrue(
+      is(
+        enhancedStore.getState().ui,
+        new Map({ isHooked: true })
+      )
+    );
+  });
+
+});


### PR DESCRIPTION
This allows us to augment the standard redux-ui reducer with the
ability to listen to custom actions:

``` js
import { reducerEnhancer } from 'redux-ui';

const enhancedReducer = reducerEnhancer((state, action) => {
  switch(action.type) {
    // ...
  }
  return state;
});
```

This will delegate to the standard `redux-ui` reducer first then run
and return state from the custom reducer.

This is the first step to allowing external actions to manipulate UI
state.
