### PR TITLE
Implement per-component custom reducers

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "jsdom": "^7.2.1",
     "mocha": "^2.3.4",
     "react-addons-test-utils": "^1.14.3",
+    "react-dom": "^0.14.3",
     "react-redux": "^4.0.1"
   },
   "dependencies": {

--- a/src/ui.js
+++ b/src/ui.js
@@ -5,11 +5,17 @@ const { any, array, func, node, object, string } = PropTypes;
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import invariant from 'invariant';
-import { updateUI, massUpdateUI, setDefaultUI, unmountUI } from './action-reducer';
+import { updateUI, massUpdateUI, setDefaultUI, mountUI, unmountUI } from './action-reducer';
 
 const connector = connect(
   (state) => { return { ui: state.ui }; },
-  (dispatch) => bindActionCreators({ updateUI, massUpdateUI, setDefaultUI, unmountUI }, dispatch)
+  (dispatch) => bindActionCreators({
+    updateUI,
+    massUpdateUI,
+    setDefaultUI,
+    mountUI,
+    unmountUI
+  }, dispatch)
 );
 
 export default function ui(key, opts = {}) {
@@ -107,7 +113,7 @@ export default function ui(key, opts = {}) {
           // If the component's UI subtree doesn't exist and we have state to
           // set ensure we update our global store with the current state.
           if (this.props.ui.getIn(this.uiPath) === undefined && opts.state)  {
-            this.context.store.dispatch(setDefaultUI(this.uiPath, opts.state));
+            this.context.store.dispatch(mountUI(this.uiPath, opts.state, opts.reducer));
           }
         }
 
@@ -134,7 +140,11 @@ export default function ui(key, opts = {}) {
         // requestAnimationFrame avoids this.
         componentWillUnmount() {
           if (opts.persist !== true) {
-            window.requestAnimationFrame(() => this.props.unmountUI(this.uiPath));
+            if (window && window.requestAnimationFrame) {
+              window.requestAnimationFrame(() => this.props.unmountUI(this.uiPath));
+            } else {
+              this.props.unmountUI(this.uiPath);
+            }
           }
         }
 

--- a/test/ui/reducer.js
+++ b/test/ui/reducer.js
@@ -1,0 +1,108 @@
+'use strict';
+
+import { assert } from 'chai'; 
+
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
+import { is, Map } from 'immutable';
+import TestUtils from 'react-addons-test-utils';
+import shallowEqual from 'react-redux/lib/utils/shallowEqual';
+
+import ui, { reducer } from '../../src';
+import { store, render, renderAndFind } from '../utils/render.js';
+
+describe('with a custom reducer', () => {
+
+  class Parent extends Component {
+    render = () => <div>{ this.props.children }</div>
+  }
+
+  // Create a UI component that listens to the 'CUSTOM' type and updates
+  // UI variables
+  let parentReducer = (state, action) => {
+    if (action.type === 'CUSTOM') {
+      return state.set('name', 'parentOverride');
+    }
+    return state;
+  };
+  const UIParent = ui({
+    key: 'parent',
+    state: {
+      name: 'parent'
+    },
+    reducer: parentReducer
+  })(Parent);
+
+  it('adds a custom reducer on mount and removes at unmount', () => {
+    const c = renderAndFind(<UIParent />, Parent);
+
+    let reducers = store.getState().ui.get('__reducers');
+    assert.equal(reducers.size, 1);
+    assert.equal(reducers.get('parent').func, parentReducer);
+
+    // Unmount and this should be gone
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(c).parentNode);
+    reducers = store.getState().ui.get('__reducers');
+    assert.equal(reducers.size, 0);
+  });
+
+  it('updates props as expected', () => {
+    const c = renderAndFind(<UIParent />, Parent);
+    assert.equal(c.props.ui.name, 'parent');
+    c.props.updateUI('name', 'foo');
+    assert.equal(c.props.ui.name, 'foo');
+
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(c).parentNode);
+  });
+
+  it('responds to actions using a custom reducer', () => {
+    const c = renderAndFind(<UIParent />, Parent);
+    store.dispatch({ type: 'CUSTOM' });
+    assert.equal(c.props.ui.name, 'parentOverride');
+
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(c).parentNode);
+  });
+
+  describe('with children', () => {
+    // This will be set when the reducer is called, allowing us to test what
+    // state the reducer is given.
+    //
+    // We should only be given state for our current component.
+    let reducerState;
+
+    // Create a UI component that listens to the 'CUSTOM' type and updates
+    // UI variables
+    let childReducer = (state, action) => {
+      reducerState = state;
+
+      if (action.type === 'CUSTOM') {
+        return state.set('foo', 'childOverride');
+      }
+      return state;
+    };
+    class Child extends Component {
+      render = () => <p>child</p>
+    }
+    const UIChild = ui({
+      key: 'child',
+      state: { foo: 'bar' },
+      reducer: childReducer
+    })(Child);
+
+    it('only gets given the UI state for the current component', () => {
+      const tree = render(<UIParent><UIChild /></UIParent>, Parent);
+      const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
+      const child = TestUtils.findRenderedComponentWithType(tree, Child);
+
+      store.dispatch({ type: 'CUSTOM' });
+      // The reducerState should equal the default reducer state for our child
+      // component
+      assert.isTrue(is(reducerState, new Map({ foo: 'bar' })));
+      assert.equal(parent.props.ui.name, 'parentOverride');
+      assert.equal(child.props.ui.foo, 'childOverride');
+
+      ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(parent).parentNode);
+    });
+  });
+
+});

--- a/test/utils/render.js
+++ b/test/utils/render.js
@@ -33,6 +33,7 @@ const renderAndFind = (jsx, type = null) => {
 }
 
 export {
+  store,
   wrapWithProvider,
   render,
   renderAndFind


### PR DESCRIPTION
This allows each component to define its own reducer which receives
and modifies the components UI state; this allows any component to
define UI state variables and react to external actions. Example:

``` js
@ui({
  key: 'someKey',
  state: {
    extraFilters: false
  },
  reducer: (state, action) => {
      // state represents *only* the UI state for this component's scope - not any children
      switch(action.type) {
      case '@@reduxReactRouter/routerDidChange':
        if (action.payload.location.query.extra_filters) {
          return state.set('extraFilters', true);
        }
      }
      return state;
    }
  }
})
class Thing extends Component {
}
```
