### PR TITLE
redux-immutablejs compatibility change

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "jsdom": "^7.2.1",
     "mocha": "^2.3.4",
     "react-addons-test-utils": "^0.14.3",
-    "react-dom": "^0.14.3"
+    "react-dom": "^0.14.3",
+    "redux-immutablejs": "0.0.8"
   },
   "dependencies": {
     "immutable": "^3.7.5",

--- a/src/ui.js
+++ b/src/ui.js
@@ -6,9 +6,12 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import invariant from 'invariant';
 import { updateUI, massUpdateUI, setDefaultUI, mountUI, unmountUI } from './action-reducer';
+import { Map } from 'immutable';
+
+const getUiState = (state) => Map.isMap(state) ? state.get('ui') : state.ui;
 
 const connector = connect(
-  (state) => { return { ui: state.ui }; },
+  (state) => { return { ui: getUiState(state) }; },
   (dispatch) => bindActionCreators({
     updateUI,
     massUpdateUI,
@@ -52,14 +55,14 @@ export default function ui(key, opts = {}) {
         constructor(props, ctx, queue) {
           super(props, ctx, queue);
 
-          // If the key is undefined generate a new random hex key for the 
+          // If the key is undefined generate a new random hex key for the
           // current component's UI scope.
           //
           // We do this in construct() to guarantee a new key at component
           // instantiation time wihch is needed for iterating through a list of
           // components with no explicit key
           if (key === undefined) {
-            this.key = (WrappedComponent.displayName || 
+            this.key = (WrappedComponent.displayName ||
                    WrappedComponent.name) +
                    Math.floor(Math.random() * (1 << 30)).toString(16);
           } else {
@@ -127,7 +130,7 @@ export default function ui(key, opts = {}) {
           // We can only see if this component's state is blown away by
           // accessing the current global UI state; the parent will not
           // necessarily always pass down child state.
-          const ui = this.context.store.getState().ui;
+          const ui = getUiState(this.context.store.getState());
           if (ui.getIn(this.uiPath) === undefined && opts.state) {
             const state = this.getDefaultUIState(opts.state, nextProps);
             this.props.setDefaultUI(this.uiPath, opts.state);
@@ -271,7 +274,7 @@ export default function ui(key, opts = {}) {
           //
           // We still use @connect() to connect to the store and listen for
           // changes in other cases.
-          let ui = this.context.store.getState().ui;
+          let ui = getUiState(this.context.store.getState());
 
           return Object.keys(this.uiVars).reduce((props, k) => {
             props[k] = ui.getIn(this.uiVars[k].concat(k));

--- a/test/ui/context.js
+++ b/test/ui/context.js
@@ -1,203 +1,213 @@
 'use strict';
 
-import { assert } from 'chai'; 
+import { assert } from 'chai';
 import React, { Component } from 'react';
 import TestUtils from 'react-addons-test-utils';
 import shallowEqual from 'react-redux/lib/utils/shallowEqual';
 
 import ui, { reducer } from '../../src';
-import { render, renderAndFind } from '../utils/render.js';
+import { render, renderAndFind, setCombineReducers } from '../utils/render.js';
 
-describe('UI state context', () => {
+['reduxCombineReducers', 'immutableCombineReducers'].forEach((cr) => {
+  describe('UI state context', () => {
+    describe(`single component tree using ${cr}`, () => {
+      before(() => setCombineReducers(cr));
 
-  describe('single component tree', () => {
-    class Test extends Component {
-      updateName() { this.props.updateUI('name', 'test'); }
-      massUpdate() {
-        this.props.updateUI({
-          name: 'test',
-          isValid: false
-        });
+      class Test extends Component {
+        updateName() { this.props.updateUI('name', 'test'); }
+        massUpdate() {
+          this.props.updateUI({
+            name: 'test',
+            isValid: false
+          });
+        }
+        render() { return <p>Hi</p>; }
       }
-      render() { return <p>Hi</p>; }
-    }
-    const uiState = {
-      name: 'parent',
-      isValid: true
-    };
-    const UITest = ui({ state: uiState })(Test);
- 
-    it('component gets given expected props', () => {
-      const c = renderAndFind(<UITest />, Test);
-      assert(typeof c.props.updateUI === 'function', 'has updateUI');
-      assert(typeof c.props.resetUI === 'function', 'has resetUI');
-      assert(typeof c.props.uiKey === 'string', 'has uiKey');
-      assert(shallowEqual(c.props.ui, uiState), 'has default state');
-    });
-
-    it('updates props using the single-update syntax', () => {
-      const c = renderAndFind(<UITest />, Test);
-      assert(c.props.ui.name === 'parent');
-      c.updateName()
-      assert(c.props.ui.name === 'test');
-    });
-
-    it('updates props using the mass-update syntax', () => {
-      const c = renderAndFind(<UITest />, Test);
-      assert(c.props.ui.name === 'parent');
-      c.massUpdate()
-      assert(c.props.ui.name === 'test');
-      assert(c.props.ui.isValid === false);
-    });
-  });
-
-  describe('single-level nested ui component tree', () => {
-    const uiState = {
-      name: 'parent'
-    };
-    class Parent extends Component {
-      updateContext(to = 'parent') { this.props.updateUI('name', to); }
-      render() { return <div>{ this.props.children }</div>; }
-    };
-    const UIParent = ui({state: uiState})(Parent);
-
-    class Child extends Component {
-      updateParentContext(to = 'parent') { this.props.updateUI('name', to); }
-      updateName() { this.props.updateUI('name', 'bar'); }
-      updateOwnState() { this.props.updateUI('child', 'foo'); }
-      render() { return <p>Nested</p>; }
-    };
-    const UIChild = ui({})(Child);
-    const UIChildWithOwnState = ui({ state: { child: true } })(Child);
-    const UIChildWithOwnStateJSX = (
-      <UIParent>
-        <UIChildWithOwnState />
-      </UIParent>
-    );
-
-    it('child component inherits parent context', () => {
-      const c = renderAndFind(<UIParent><UIChild /></UIParent>, Child);
-      assert(shallowEqual(c.props.ui, uiState), 'child inherits parent UI state context');
-    });
-
-    it('parent component only gets its own context', () => {
-      const p = renderAndFind(UIChildWithOwnStateJSX, Parent);
-      assert(shallowEqual(p.props.ui, uiState), 'parent only has its own context and not childrens');
-    });
-
-    it('child component updates parent variables', () => {
-      const tree = render(<UIParent><UIChild /></UIParent>);
-      const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
-      const child = TestUtils.findRenderedComponentWithType(tree, Child);
-
-      assert(parent.props.ui.name === 'parent');
-      assert(child.props.ui.name === 'parent');
-      child.updateName();
-      assert(parent.props.ui.name === 'bar');
-      assert(child.props.ui.name === 'bar');
-    });
-
-    it('child merges parent UI context with its own UI context', () => {
-      const child = renderAndFind(UIChildWithOwnStateJSX, Child);
-      const expectedState = {
+      const uiState = {
         name: 'parent',
-        child: true
+        isValid: true
       };
-      assert(shallowEqual(child.props.ui, expectedState), 'child merges context');
+      const UITest = ui({ state: uiState })(Test);
+
+      it('component gets given expected props', () => {
+        const c = renderAndFind(<UITest />, Test);
+        assert(typeof c.props.updateUI === 'function', 'has updateUI');
+        assert(typeof c.props.resetUI === 'function', 'has resetUI');
+        assert(typeof c.props.uiKey === 'string', 'has uiKey');
+        assert(shallowEqual(c.props.ui, uiState), 'has default state');
+      });
+
+      it('updates props using the single-update syntax', () => {
+        const c = renderAndFind(<UITest />, Test);
+        assert(c.props.ui.name === 'parent');
+        c.updateName()
+        assert(c.props.ui.name === 'test');
+      });
+
+      it('updates props using the mass-update syntax', () => {
+        const c = renderAndFind(<UITest />, Test);
+        assert(c.props.ui.name === 'parent');
+        c.massUpdate()
+        assert(c.props.ui.name === 'test');
+        assert(c.props.ui.isValid === false);
+      });
     });
 
-    it('child updates own context separately from parent', () => {
-      const tree = render(UIChildWithOwnStateJSX);
-      const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
-      const child = TestUtils.findRenderedComponentWithType(tree, Child);
-      child.updateOwnState();
-      assert(child.props.ui.child === 'foo', 'child updates own context');
-      assert(parent.props.ui.child === undefined, 'parent has no child state in its context');
-    });
+    describe(`single-level nested ui component tree using ${cr}`, () => {
+      before(() => setCombineReducers(cr));
 
-    it('child updates parent context', () => {
-      const tree = render(UIChildWithOwnStateJSX);
-      const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
-      const child = TestUtils.findRenderedComponentWithType(tree, Child);
+      const uiState = {
+        name: 'parent'
+      };
+      class Parent extends Component {
+        updateContext(to = 'parent') { this.props.updateUI('name', to); }
+        render() { return <div>{ this.props.children }</div>; }
+      };
+      const UIParent = ui({state: uiState})(Parent);
 
-      child.updateParentContext('foobar');
-      assert(parent.props.ui.name === 'foobar', 'parent updates context');
-      assert(child.props.ui.name === 'foobar', 'child updates context');
-    });
-
-    it('parent updating context sends child new context and child receives updates', () => {
-      const tree = render(UIChildWithOwnStateJSX);
-      const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
-      const child = TestUtils.findRenderedComponentWithType(tree, Child);
-
-      parent.updateContext('what');
-      assert(parent.props.ui.name === 'what', 'parent updates context');
-      assert(child.props.ui.name === 'what', 'child updates context');
-    });
-
-    describe('duplicating UI variable names across parent/child contexts', () => {
       class Child extends Component {
-        updateChildContext(to = 'foo') { this.props.updateUI('name', to); }
-        render() { return <div /> }
-      }
-      const UIChild = ui({ state: { name: 'child' } })(Child);
-      const UIChildJSX = (<UIParent><UIChild /></UIParent>);
+        updateParentContext(to = 'parent') { this.props.updateUI('name', to); }
+        updateName() { this.props.updateUI('name', 'bar'); }
+        updateOwnState() { this.props.updateUI('child', 'foo'); }
+        render() { return <p>Nested</p>; }
+      };
+      const UIChild = ui({})(Child);
+      const UIChildWithOwnState = ui({ state: { child: true } })(Child);
+      const UIChildWithOwnStateJSX = (
+        <UIParent>
+          <UIChildWithOwnState />
+        </UIParent>
+      );
 
-      it('parent and child store state separately', () => {
-        const tree = render(UIChildJSX);
+      it('child component inherits parent context', () => {
+        const c = renderAndFind(<UIParent><UIChild /></UIParent>, Child);
+        assert(shallowEqual(c.props.ui, uiState), 'child inherits parent UI state context');
+      });
+
+      it('parent component only gets its own context', () => {
+        const p = renderAndFind(UIChildWithOwnStateJSX, Parent);
+        assert(shallowEqual(p.props.ui, uiState), 'parent only has its own context and not childrens');
+      });
+
+      it('child component updates parent variables', () => {
+        const tree = render(<UIParent><UIChild /></UIParent>);
         const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
         const child = TestUtils.findRenderedComponentWithType(tree, Child);
 
         assert(parent.props.ui.name === 'parent');
-        assert(child.props.ui.name === 'child');
-      }); 
+        assert(child.props.ui.name === 'parent');
+        child.updateName();
+        assert(parent.props.ui.name === 'bar');
+        assert(child.props.ui.name === 'bar');
+      });
 
-      it('parent updates context separately from parent', () => {
-        const tree = render(UIChildJSX);
+      it('child merges parent UI context with its own UI context', () => {
+        const child = renderAndFind(UIChildWithOwnStateJSX, Child);
+        const expectedState = {
+          name: 'parent',
+          child: true
+        };
+        assert(shallowEqual(child.props.ui, expectedState), 'child merges context');
+      });
+
+      it('child updates own context separately from parent', () => {
+        const tree = render(UIChildWithOwnStateJSX);
+        const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
+        const child = TestUtils.findRenderedComponentWithType(tree, Child);
+        child.updateOwnState();
+        assert(child.props.ui.child === 'foo', 'child updates own context');
+        assert(parent.props.ui.child === undefined, 'parent has no child state in its context');
+      });
+
+      it('child updates parent context', () => {
+        const tree = render(UIChildWithOwnStateJSX);
         const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
         const child = TestUtils.findRenderedComponentWithType(tree, Child);
 
-        parent.updateContext('foobar');
-        assert(parent.props.ui.name === 'foobar');
-        assert(child.props.ui.name === 'child');
-      }); 
+        child.updateParentContext('foobar');
+        assert(parent.props.ui.name === 'foobar', 'parent updates context');
+        assert(child.props.ui.name === 'foobar', 'child updates context');
+      });
 
-
-      it('child updates context separately from parent', () => {
-        const tree = render(UIChildJSX);
+      it('parent updating context sends child new context and child receives updates', () => {
+        const tree = render(UIChildWithOwnStateJSX);
         const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
         const child = TestUtils.findRenderedComponentWithType(tree, Child);
 
-        child.updateChildContext('foobar');
-        assert(parent.props.ui.name === 'parent');
-        assert(child.props.ui.name === 'foobar');
-      }); 
+        parent.updateContext('what');
+        assert(parent.props.ui.name === 'what', 'parent updates context');
+        assert(child.props.ui.name === 'what', 'child updates context');
+      });
+
+      describe(`duplicating UI variable names across parent/child contexts using ${cr}`, () => {
+        before(() => setCombineReducers(cr));
+
+        class Child extends Component {
+          updateChildContext(to = 'foo') { this.props.updateUI('name', to); }
+          render() { return <div /> }
+        }
+        const UIChild = ui({ state: { name: 'child' } })(Child);
+        const UIChildJSX = (<UIParent><UIChild /></UIParent>);
+
+        it('parent and child store state separately', () => {
+          const tree = render(UIChildJSX);
+          const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
+          const child = TestUtils.findRenderedComponentWithType(tree, Child);
+
+          assert(parent.props.ui.name === 'parent');
+          assert(child.props.ui.name === 'child');
+        });
+
+        it('parent updates context separately from parent', () => {
+          const tree = render(UIChildJSX);
+          const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
+          const child = TestUtils.findRenderedComponentWithType(tree, Child);
+
+          parent.updateContext('foobar');
+          assert(parent.props.ui.name === 'foobar');
+          assert(child.props.ui.name === 'child');
+        });
+
+
+        it('child updates context separately from parent', () => {
+          const tree = render(UIChildJSX);
+          const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
+          const child = TestUtils.findRenderedComponentWithType(tree, Child);
+
+          child.updateChildContext('foobar');
+          assert(parent.props.ui.name === 'parent');
+          assert(child.props.ui.name === 'foobar');
+        });
+      });
+
     });
 
-  });
+    describe(`shared contexts using ${cr}`, () => {
+      before(() => setCombineReducers(cr));
 
-  describe('shared contexts', () => {
-    class Foo extends Component {
-      updateContext(to = 'misc') { this.props.updateUI('name', to); }
-      render = () => <div />
-    }
-    class Bar extends Component {
-      updateContext(to = 'misc') { this.props.updateUI('name', to); }
-      render = () => <div />
-    }
-    const adapter = ui({ key: 'a', state: { name: 'name' } });
-    const UIFoo = adapter(Foo);
-    const UIBar = adapter(Bar);
+      class Foo extends Component {
+        updateContext(to = 'misc') { this.props.updateUI('name', to); }
+        render = () => <div />
+      }
+      class Bar extends Component {
+        updateContext(to = 'misc') { this.props.updateUI('name', to); }
+        render = () => <div />
+      }
+      const adapter = ui({ key: 'a', state: { name: 'name' } });
+      const UIFoo = adapter(Foo);
+      const UIBar = adapter(Bar);
 
-    it('components with the same key and nesting share the same context', () => {
-        const tree = render(<div><UIFoo /><UIBar /></div>);
-        const a = TestUtils.findRenderedComponentWithType(tree, Foo);
-        const b = TestUtils.findRenderedComponentWithType(tree, Bar);
+      it('components with the same key and nesting share the same context', () => {
+          const tree = render(<div><UIFoo /><UIBar /></div>);
+          const a = TestUtils.findRenderedComponentWithType(tree, Foo);
+          const b = TestUtils.findRenderedComponentWithType(tree, Bar);
 
-        assert(shallowEqual(a.props.ui, b.props.ui));
-        a.updateContext();
-        assert(a.props.ui.name === 'misc');
-        assert(shallowEqual(a.props.ui, b.props.ui));
+          assert(shallowEqual(a.props.ui, b.props.ui));
+          a.updateContext();
+          assert(a.props.ui.name === 'misc');
+          assert(shallowEqual(a.props.ui, b.props.ui));
+      });
+
     });
 
   });

--- a/test/ui/defaults.js
+++ b/test/ui/defaults.js
@@ -1,43 +1,48 @@
 
 'use strict';
 
-import { assert } from 'chai'; 
+import { assert } from 'chai';
 import React, { Component } from 'react';
 import TestUtils from 'react-addons-test-utils';
 import shallowEqual from 'react-redux/lib/utils/shallowEqual';
 import { Map } from 'immutable';
 
 import ui, { reducer } from '../../src';
-import { render, renderAndFind } from '../utils/render.js';
+import { render, renderAndFind, setCombineReducers, getUiState } from '../utils/render.js';
 
-describe('Default UI state variables', () => {
+['reduxCombineReducers', 'immutableCombineReducers'].forEach((cr) => {
 
-  describe('HOC is passed props and state to calculate defaults', () => {
-    // Set up closures which we can use to check that the uiState func is passed
-    // expected props.
-    let calcProps, calcState;
+  describe('Default UI state variables', () => {
 
-    class Test extends Component {
-      render() { return <p>Hi</p>; }
-    }
-    const uiState = {
-      calculated: (props, state) => {
-        calcProps = props;
-        calcState = state;
-        return props.passedProp
-      },
-      isValid: true
-    };
-    const UITest = ui({ state: uiState })(Test);
- 
-    it('component gets given expected props', () => {
-      const c = renderAndFind(<UITest passedProp='foo' />, Test);
-      assert.equal(c.props.ui.calculated, 'foo');
-      assert.equal(calcProps.passedProp, 'foo');
-      assert.equal(typeof calcState.ui, typeof Map());
+    describe(`HOC is passed props and state to calculate defaults using ${cr}`, () => {
+      before(() => setCombineReducers(cr));
+
+      // Set up closures which we can use to check that the uiState func is passed
+      // expected props.
+      let calcProps, calcState;
+
+      class Test extends Component {
+        render() { return <p>Hi</p>; }
+      }
+      const uiState = {
+        calculated: (props, state) => {
+          calcProps = props;
+          calcState = state;
+          return props.passedProp
+        },
+        isValid: true
+      };
+      const UITest = ui({ state: uiState })(Test);
+
+      it('component gets given expected props', () => {
+        const c = renderAndFind(<UITest passedProp='foo' />, Test);
+        assert.equal(c.props.ui.calculated, 'foo');
+        assert.equal(calcProps.passedProp, 'foo');
+        assert.equal(typeof getUiState(calcState, cr), typeof Map());
+      });
+
     });
 
   });
 
 });
-

--- a/test/ui/reducer.js
+++ b/test/ui/reducer.js
@@ -9,100 +9,106 @@ import TestUtils from 'react-addons-test-utils';
 import shallowEqual from 'react-redux/lib/utils/shallowEqual';
 
 import ui, { reducer } from '../../src';
-import { store, render, renderAndFind } from '../utils/render.js';
+import { store, render, renderAndFind, setCombineReducers, getUiState } from '../utils/render.js';
 
-describe('with a custom reducer', () => {
+['reduxCombineReducers', 'immutableCombineReducers'].forEach((cr) => {
 
-  class Parent extends Component {
-    render = () => <div>{ this.props.children }</div>
-  }
+  describe(`with a custom reducer using ${cr}`, () => {
+    before(() => setCombineReducers(cr));
 
-  // Create a UI component that listens to the 'CUSTOM' type and updates
-  // UI variables
-  let parentReducer = (state, action) => {
-    if (action.type === 'CUSTOM') {
-      return state.set('name', 'parentOverride');
+    class Parent extends Component {
+      render = () => <div>{ this.props.children }</div>
     }
-    return state;
-  };
-  const UIParent = ui({
-    key: 'parent',
-    state: {
-      name: 'parent'
-    },
-    reducer: parentReducer
-  })(Parent);
-
-  it('adds a custom reducer on mount and removes at unmount', () => {
-    const c = renderAndFind(<UIParent />, Parent);
-
-    let reducers = store().getState().ui.get('__reducers');
-    assert.equal(reducers.size, 1);
-    assert.equal(reducers.get('parent').func, parentReducer);
-
-    // Unmount and this should be gone
-    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(c).parentNode);
-    reducers = store().getState().ui.get('__reducers');
-    assert.equal(reducers.size, 0);
-  });
-
-  it('updates props as expected', () => {
-    const c = renderAndFind(<UIParent />, Parent);
-    assert.equal(c.props.ui.name, 'parent');
-    c.props.updateUI('name', 'foo');
-    assert.equal(c.props.ui.name, 'foo');
-
-    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(c).parentNode);
-  });
-
-  it('responds to actions using a custom reducer', () => {
-    const c = renderAndFind(<UIParent />, Parent);
-    store().dispatch({ type: 'CUSTOM' });
-    assert.equal(c.props.ui.name, 'parentOverride');
-
-    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(c).parentNode);
-  });
-
-  describe('with children', () => {
-    // This will be set when the reducer is called, allowing us to test what
-    // state the reducer is given.
-    //
-    // We should only be given state for our current component.
-    let reducerState;
 
     // Create a UI component that listens to the 'CUSTOM' type and updates
     // UI variables
-    let childReducer = (state, action) => {
-      reducerState = state;
-
+    let parentReducer = (state, action) => {
       if (action.type === 'CUSTOM') {
-        return state.set('foo', 'childOverride');
+        return state.set('name', 'parentOverride');
       }
       return state;
     };
-    class Child extends Component {
-      render = () => <p>child</p>
-    }
-    const UIChild = ui({
-      key: 'child',
-      state: { foo: 'bar' },
-      reducer: childReducer
-    })(Child);
+    const UIParent = ui({
+      key: 'parent',
+      state: {
+        name: 'parent'
+      },
+      reducer: parentReducer
+    })(Parent);
 
-    it('only gets given the UI state for the current component', () => {
-      const tree = render(<UIParent><UIChild /></UIParent>, Parent);
-      const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
-      const child = TestUtils.findRenderedComponentWithType(tree, Child);
+    it('adds a custom reducer on mount and removes at unmount', () => {
+      const c = renderAndFind(<UIParent />, Parent);
+      let reducers = getUiState(store.getState(), cr).get('__reducers');
+      assert.equal(reducers.size, 1);
+      assert.equal(reducers.get('parent').func, parentReducer);
 
-      store().dispatch({ type: 'CUSTOM' });
-      // The reducerState should equal the default reducer state for our child
-      // component
-      assert.isTrue(is(reducerState, new Map({ foo: 'bar' })));
-      assert.equal(parent.props.ui.name, 'parentOverride');
-      assert.equal(child.props.ui.foo, 'childOverride');
-
-      ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(parent).parentNode);
+      // Unmount and this should be gone
+      ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(c).parentNode);
+      reducers = getUiState(store.getState(), cr).get('__reducers');
+      assert.equal(reducers.size, 0);
     });
+
+    it('updates props as expected', () => {
+      const c = renderAndFind(<UIParent />, Parent);
+      assert.equal(c.props.ui.name, 'parent');
+      c.props.updateUI('name', 'foo');
+      assert.equal(c.props.ui.name, 'foo');
+
+      ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(c).parentNode);
+    });
+
+    it('responds to actions using a custom reducer', () => {
+      const c = renderAndFind(<UIParent />, Parent);
+      store.dispatch({ type: 'CUSTOM' });
+      assert.equal(c.props.ui.name, 'parentOverride');
+
+      ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(c).parentNode);
+    });
+
+    describe(`with children using ${cr}`, () => {
+      before(() => setCombineReducers(cr));
+
+      // This will be set when the reducer is called, allowing us to test what
+      // state the reducer is given.
+      //
+      // We should only be given state for our current component.
+      let reducerState;
+
+      // Create a UI component that listens to the 'CUSTOM' type and updates
+      // UI variables
+      let childReducer = (state, action) => {
+        reducerState = state;
+
+        if (action.type === 'CUSTOM') {
+          return state.set('foo', 'childOverride');
+        }
+        return state;
+      };
+      class Child extends Component {
+        render = () => <p>child</p>
+      }
+      const UIChild = ui({
+        key: 'child',
+        state: { foo: 'bar' },
+        reducer: childReducer
+      })(Child);
+
+      it('only gets given the UI state for the current component', () => {
+        const tree = render(<UIParent><UIChild /></UIParent>, Parent);
+        const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
+        const child = TestUtils.findRenderedComponentWithType(tree, Child);
+
+        store.dispatch({ type: 'CUSTOM' });
+        // The reducerState should equal the default reducer state for our child
+        // component
+        assert.isTrue(is(reducerState, new Map({ foo: 'bar' })));
+        assert.equal(parent.props.ui.name, 'parentOverride');
+        assert.equal(child.props.ui.foo, 'childOverride');
+
+        ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(parent).parentNode);
+      });
+    });
+
   });
 
 });

--- a/test/ui/reducer.js
+++ b/test/ui/reducer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { assert } from 'chai'; 
+import { assert } from 'chai';
 
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
@@ -36,13 +36,13 @@ describe('with a custom reducer', () => {
   it('adds a custom reducer on mount and removes at unmount', () => {
     const c = renderAndFind(<UIParent />, Parent);
 
-    let reducers = store.getState().ui.get('__reducers');
+    let reducers = store().getState().ui.get('__reducers');
     assert.equal(reducers.size, 1);
     assert.equal(reducers.get('parent').func, parentReducer);
 
     // Unmount and this should be gone
     ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(c).parentNode);
-    reducers = store.getState().ui.get('__reducers');
+    reducers = store().getState().ui.get('__reducers');
     assert.equal(reducers.size, 0);
   });
 
@@ -57,7 +57,7 @@ describe('with a custom reducer', () => {
 
   it('responds to actions using a custom reducer', () => {
     const c = renderAndFind(<UIParent />, Parent);
-    store.dispatch({ type: 'CUSTOM' });
+    store().dispatch({ type: 'CUSTOM' });
     assert.equal(c.props.ui.name, 'parentOverride');
 
     ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(c).parentNode);
@@ -94,7 +94,7 @@ describe('with a custom reducer', () => {
       const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
       const child = TestUtils.findRenderedComponentWithType(tree, Child);
 
-      store.dispatch({ type: 'CUSTOM' });
+      store().dispatch({ type: 'CUSTOM' });
       // The reducerState should equal the default reducer state for our child
       // component
       assert.isTrue(is(reducerState, new Map({ foo: 'bar' })));

--- a/test/ui/reset.js
+++ b/test/ui/reset.js
@@ -1,61 +1,65 @@
 'use strict';
 
-import { assert } from 'chai'; 
+import { assert } from 'chai';
 import React, { Component } from 'react';
 import TestUtils from 'react-addons-test-utils';
 import shallowEqual from 'react-redux/lib/utils/shallowEqual';
 
 import ui, { reducer } from '../../src';
-import { render, renderAndFind } from '../utils/render.js';
+import { render, renderAndFind, setCombineReducers } from '../utils/render.js';
 
-describe('resetting UI state', () => {
-  class Parent extends Component {
-    render = () => (<div>{ this.props.children }</div>)
-  }
+['reduxCombineReducers', 'immutableCombineReducers'].forEach((cr) => {
+  describe('resetting UI state', () => {
+    before(() => setCombineReducers(cr));
 
-  class Child extends Component {
-    render = () => <p>Child</p>
-  }
+    class Parent extends Component {
+      render = () => (<div>{ this.props.children }</div>)
+    }
 
-  const UIParent = ui({ state: { name: 'parent' } })(Parent);
-  const UIChild = ui({ state: { name: 'child' } })(Child);
+    class Child extends Component {
+      render = () => <p>Child</p>
+    }
 
-  it('resetting a UI component with no children resets its own UI state', () => {
-    const child = renderAndFind(<UIChild />, Child);
+    const UIParent = ui({ state: { name: 'parent' } })(Parent);
+    const UIChild = ui({ state: { name: 'child' } })(Child);
 
-    child.props.updateUI({ name: 'foobar' });
-    assert(child.props.ui.name === 'foobar');
-    child.props.resetUI();
-    assert(child.props.ui.name === 'child');
-  });
+    it('resetting a UI component with no children resets its own UI state', () => {
+      const child = renderAndFind(<UIChild />, Child);
 
-  it('resetting a parent UI resets its own AND child contexts', () => {
-      const tree = render(<UIParent><UIChild /></UIParent>);
-      const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
-      const child = TestUtils.findRenderedComponentWithType(tree, Child);
-
-      child.props.updateUI({ name: 'b' });
-      parent.props.updateUI({ name: 'a' });
-      // Ensure state is updated
-      assert(child.props.ui.name === 'b');
-      // Resetting a parent should also reset all children
-      parent.props.resetUI();
-      assert(child.props.ui.name === 'child');
-      assert(parent.props.ui.name === 'parent');
-  });
-
-  it('resetting a child UI resets only its own context', () => {
-      const tree = render(<UIParent><UIChild /></UIParent>);
-      const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
-      const child = TestUtils.findRenderedComponentWithType(tree, Child);
-
-      child.props.updateUI({ name: 'b' });
-      parent.props.updateUI({ name: 'a' });
-      // Ensure state is updated
-      assert(child.props.ui.name === 'b');
-      // Child should only reset itself to child; parent should stay changed
+      child.props.updateUI({ name: 'foobar' });
+      assert(child.props.ui.name === 'foobar');
       child.props.resetUI();
       assert(child.props.ui.name === 'child');
-      assert(parent.props.ui.name === 'a');
+    });
+
+    it('resetting a parent UI resets its own AND child contexts', () => {
+        const tree = render(<UIParent><UIChild /></UIParent>);
+        const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
+        const child = TestUtils.findRenderedComponentWithType(tree, Child);
+
+        child.props.updateUI({ name: 'b' });
+        parent.props.updateUI({ name: 'a' });
+        // Ensure state is updated
+        assert(child.props.ui.name === 'b');
+        // Resetting a parent should also reset all children
+        parent.props.resetUI();
+        assert(child.props.ui.name === 'child');
+        assert(parent.props.ui.name === 'parent');
+    });
+
+    it('resetting a child UI resets only its own context', () => {
+        const tree = render(<UIParent><UIChild /></UIParent>);
+        const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
+        const child = TestUtils.findRenderedComponentWithType(tree, Child);
+
+        child.props.updateUI({ name: 'b' });
+        parent.props.updateUI({ name: 'a' });
+        // Ensure state is updated
+        assert(child.props.ui.name === 'b');
+        // Child should only reset itself to child; parent should stay changed
+        child.props.resetUI();
+        assert(child.props.ui.name === 'child');
+        assert(parent.props.ui.name === 'a');
+    });
   });
 });

--- a/test/utils/render.js
+++ b/test/utils/render.js
@@ -2,17 +2,29 @@
 
 import React from 'react';
 import { Provider } from 'react-redux';
-import { createStore, combineReducers } from 'redux';
+import { createStore, combineReducers as reduxCombineReducers } from 'redux';
+import { combineReducers as immutableCombineReducers } from 'redux-immutablejs';
 import ui, { reducer } from '../../src';
 import TestUtils from 'react-addons-test-utils';
 
-const store = createStore(combineReducers({ ui: reducer }));
+let _combineReducers = reduxCombineReducers;
+const setCombineReducers = (cr) => {
+  _combineReducers = (cr === 'reduxCombineReducers') ? reduxCombineReducers : immutableCombineReducers;
+}
+
+let store = null;
+const initStore = () => {
+  store = createStore(_combineReducers({ ui: reducer }));
+  return store;
+}
+
+const getUiState = (state, cr) => (cr === 'immutableCombineReducers') ? state.get('ui') : state.ui;
 
 /**
  * Wrap given JSX with a provider contianing a store with the UI reducer
  */
 const wrapWithProvider = (jsx) => (
-  <Provider store={ store }>
+  <Provider store={ initStore() }>
     { jsx }
   </Provider>
 );
@@ -36,5 +48,7 @@ export {
   store,
   wrapWithProvider,
   render,
-  renderAndFind
+  renderAndFind,
+  setCombineReducers,
+  getUiState
 }


### PR DESCRIPTION
Hi, here I am proposing a change which allows users to use combineReducer from redux-immutablejs.

I made a small change on ui.js to accomodate immutablejs Map object as state in addition to js object.
I also updated some tests to execute both combineReducer from redux and the one form redux-immutablejs.
