### PR TITLE
Update dependencies to fix peerDependency failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,14 +32,14 @@
     "chai": "^3.4.1",
     "jsdom": "^7.2.1",
     "mocha": "^2.3.4",
-    "react-addons-test-utils": "^0.14.3",
-    "react-dom": "^0.14.3"
+    "react-addons-test-utils": "^0.14.3 || ^15.x",
+    "react-dom": "^0.14.3 || ^15.x"
   },
   "dependencies": {
     "babel-register": "^6.6.0",
     "immutable": "^3.7.5",
     "invariant": "^2.2.0",
-    "react": "^0.14.3 || ^15.0.1",
+    "react": "^0.14.3 || ^15.x",
     "react-redux": "^4.0.0",
     "redux": "^3.0.4"
   }


### PR DESCRIPTION
Allow any version of React 15 to be used with Redux UI. Works with .0 through .3.
