### PR TITLE
Bumped to react v15.5.0 with prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,14 +32,14 @@
     "chai": "^3.4.1",
     "jsdom": "^7.2.1",
     "mocha": "^2.3.4",
-    "react-addons-test-utils": "^0.14.3",
-    "react-dom": "^0.14.3"
+    "react-dom": "15.5.0"
   },
   "dependencies": {
     "babel-register": "^6.6.0",
     "immutable": "^3.7.5",
     "invariant": "^2.2.0",
-    "react": "^0.14.3 || ^15.0.1",
+    "prop-types": "^15.5.7",
+    "react": "^0.14.9 || ^15.3.0",
     "react-redux": "^4.0.0",
     "redux": "^3.0.4"
   }

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,7 +1,7 @@
 'use strict';
 
-import React, { Component, PropTypes } from 'react';
-const { any, array, func, node, object, string } = PropTypes;
+import React, { Component } from 'react';
+import { any, array, func, node, object, string } from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import invariant from 'invariant';

--- a/test/ui/context.js
+++ b/test/ui/context.js
@@ -1,8 +1,8 @@
 'use strict';
 
-import { assert } from 'chai'; 
+import { assert } from 'chai';
 import React, { Component } from 'react';
-import TestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 import shallowEqual from 'react-redux/lib/utils/shallowEqual';
 
 import ui, { reducer } from '../../src';
@@ -26,7 +26,7 @@ describe('UI state context', () => {
       isValid: true
     };
     const UITest = ui({ state: uiState })(Test);
- 
+
     it('component gets given expected props', () => {
       const c = renderAndFind(<UITest />, Test);
       assert(typeof c.props.updateUI === 'function', 'has updateUI');
@@ -87,8 +87,8 @@ describe('UI state context', () => {
 
     it('child component updates parent variables', () => {
       const tree = render(<UIParent><UIChild /></UIParent>);
-      const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
-      const child = TestUtils.findRenderedComponentWithType(tree, Child);
+      const parent = ReactTestUtils.findRenderedComponentWithType(tree, Parent);
+      const child = ReactTestUtils.findRenderedComponentWithType(tree, Child);
 
       assert(parent.props.ui.name === 'parent');
       assert(child.props.ui.name === 'parent');
@@ -108,8 +108,8 @@ describe('UI state context', () => {
 
     it('child updates own context separately from parent', () => {
       const tree = render(UIChildWithOwnStateJSX);
-      const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
-      const child = TestUtils.findRenderedComponentWithType(tree, Child);
+      const parent = ReactTestUtils.findRenderedComponentWithType(tree, Parent);
+      const child = ReactTestUtils.findRenderedComponentWithType(tree, Child);
       child.updateOwnState();
       assert(child.props.ui.child === 'foo', 'child updates own context');
       assert(parent.props.ui.child === undefined, 'parent has no child state in its context');
@@ -117,8 +117,8 @@ describe('UI state context', () => {
 
     it('child updates parent context', () => {
       const tree = render(UIChildWithOwnStateJSX);
-      const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
-      const child = TestUtils.findRenderedComponentWithType(tree, Child);
+      const parent = ReactTestUtils.findRenderedComponentWithType(tree, Parent);
+      const child = ReactTestUtils.findRenderedComponentWithType(tree, Child);
 
       child.updateParentContext('foobar');
       assert(parent.props.ui.name === 'foobar', 'parent updates context');
@@ -127,8 +127,8 @@ describe('UI state context', () => {
 
     it('parent updating context sends child new context and child receives updates', () => {
       const tree = render(UIChildWithOwnStateJSX);
-      const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
-      const child = TestUtils.findRenderedComponentWithType(tree, Child);
+      const parent = ReactTestUtils.findRenderedComponentWithType(tree, Parent);
+      const child = ReactTestUtils.findRenderedComponentWithType(tree, Child);
 
       parent.updateContext('what');
       assert(parent.props.ui.name === 'what', 'parent updates context');
@@ -145,33 +145,33 @@ describe('UI state context', () => {
 
       it('parent and child store state separately', () => {
         const tree = render(UIChildJSX);
-        const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
-        const child = TestUtils.findRenderedComponentWithType(tree, Child);
+        const parent = ReactTestUtils.findRenderedComponentWithType(tree, Parent);
+        const child = ReactTestUtils.findRenderedComponentWithType(tree, Child);
 
         assert(parent.props.ui.name === 'parent');
         assert(child.props.ui.name === 'child');
-      }); 
+      });
 
       it('parent updates context separately from parent', () => {
         const tree = render(UIChildJSX);
-        const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
-        const child = TestUtils.findRenderedComponentWithType(tree, Child);
+        const parent = ReactTestUtils.findRenderedComponentWithType(tree, Parent);
+        const child = ReactTestUtils.findRenderedComponentWithType(tree, Child);
 
         parent.updateContext('foobar');
         assert(parent.props.ui.name === 'foobar');
         assert(child.props.ui.name === 'child');
-      }); 
+      });
 
 
       it('child updates context separately from parent', () => {
         const tree = render(UIChildJSX);
-        const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
-        const child = TestUtils.findRenderedComponentWithType(tree, Child);
+        const parent = ReactTestUtils.findRenderedComponentWithType(tree, Parent);
+        const child = ReactTestUtils.findRenderedComponentWithType(tree, Child);
 
         child.updateChildContext('foobar');
         assert(parent.props.ui.name === 'parent');
         assert(child.props.ui.name === 'foobar');
-      }); 
+      });
     });
 
   });
@@ -191,8 +191,8 @@ describe('UI state context', () => {
 
     it('components with the same key and nesting share the same context', () => {
         const tree = render(<div><UIFoo /><UIBar /></div>);
-        const a = TestUtils.findRenderedComponentWithType(tree, Foo);
-        const b = TestUtils.findRenderedComponentWithType(tree, Bar);
+        const a = ReactTestUtils.findRenderedComponentWithType(tree, Foo);
+        const b = ReactTestUtils.findRenderedComponentWithType(tree, Bar);
 
         assert(shallowEqual(a.props.ui, b.props.ui));
         a.updateContext();

--- a/test/ui/defaults.js
+++ b/test/ui/defaults.js
@@ -1,9 +1,9 @@
 
 'use strict';
 
-import { assert } from 'chai'; 
+import { assert } from 'chai';
 import React, { Component } from 'react';
-import TestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 import shallowEqual from 'react-redux/lib/utils/shallowEqual';
 import { Map } from 'immutable';
 
@@ -29,7 +29,7 @@ describe('Default UI state variables', () => {
       isValid: true
     };
     const UITest = ui({ state: uiState })(Test);
- 
+
     it('component gets given expected props', () => {
       const c = renderAndFind(<UITest passedProp='foo' />, Test);
       assert.equal(c.props.ui.calculated, 'foo');

--- a/test/ui/key.js
+++ b/test/ui/key.js
@@ -1,8 +1,8 @@
 'use strict';
 
-import { assert } from 'chai'; 
+import { assert } from 'chai';
 import React, { Component } from 'react';
-import TestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 
 import ui, { reducer } from '../../src';
 import { render, renderAndFind } from '../utils/render.js';
@@ -26,7 +26,7 @@ describe('key generation', () => {
           <WrappedTestWithoutKey />
         </div>
       );
-      const comps = TestUtils
+      const comps = ReactTestUtils
         .scryRenderedComponentsWithType(tree, Test);
       const { uiKey } = comps[0].props;
 
@@ -45,7 +45,7 @@ describe('key generation', () => {
   describe('opts.key !== undefined', () => {
     it('uses the specified key', () => {
       const tree = render(<WrappedTestWithKey />);
-      const c = TestUtils.findRenderedComponentWithType(tree, Test);
+      const c = ReactTestUtils.findRenderedComponentWithType(tree, Test);
       const { uiKey } = c.props;
 
       // Check basic setup of the UI key within the first component

--- a/test/ui/opts.js
+++ b/test/ui/opts.js
@@ -1,8 +1,8 @@
 'use strict';
 
-import { assert } from 'chai'; 
+import { assert } from 'chai';
 import React, { Component } from 'react';
-import TestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 import shallowEqual from 'react-redux/lib/utils/shallowEqual';
 
 import ui, { reducer } from '../../src';

--- a/test/ui/reducer.js
+++ b/test/ui/reducer.js
@@ -1,11 +1,11 @@
 'use strict';
 
-import { assert } from 'chai'; 
+import { assert } from 'chai';
 
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import { is, Map } from 'immutable';
-import TestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 import shallowEqual from 'react-redux/lib/utils/shallowEqual';
 
 import ui, { reducer } from '../../src';
@@ -90,8 +90,8 @@ describe('with a custom reducer', () => {
 
     it('only gets given the UI state for the current component', () => {
       const tree = render(<UIParent><UIChild /></UIParent>, Parent);
-      const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
-      const child = TestUtils.findRenderedComponentWithType(tree, Child);
+      const parent = ReactTestUtils.findRenderedComponentWithType(tree, Parent);
+      const child = ReactTestUtils.findRenderedComponentWithType(tree, Child);
 
       store.dispatch({ type: 'CUSTOM' });
       // The reducerState should equal the default reducer state for our child

--- a/test/ui/reset.js
+++ b/test/ui/reset.js
@@ -1,8 +1,8 @@
 'use strict';
 
-import { assert } from 'chai'; 
+import { assert } from 'chai';
 import React, { Component } from 'react';
-import TestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 import shallowEqual from 'react-redux/lib/utils/shallowEqual';
 
 import ui, { reducer } from '../../src';
@@ -31,8 +31,8 @@ describe('resetting UI state', () => {
 
   it('resetting a parent UI resets its own AND child contexts', () => {
       const tree = render(<UIParent><UIChild /></UIParent>);
-      const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
-      const child = TestUtils.findRenderedComponentWithType(tree, Child);
+      const parent = ReactTestUtils.findRenderedComponentWithType(tree, Parent);
+      const child = ReactTestUtils.findRenderedComponentWithType(tree, Child);
 
       child.props.updateUI({ name: 'b' });
       parent.props.updateUI({ name: 'a' });
@@ -46,8 +46,8 @@ describe('resetting UI state', () => {
 
   it('resetting a child UI resets only its own context', () => {
       const tree = render(<UIParent><UIChild /></UIParent>);
-      const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
-      const child = TestUtils.findRenderedComponentWithType(tree, Child);
+      const parent = ReactTestUtils.findRenderedComponentWithType(tree, Parent);
+      const child = ReactTestUtils.findRenderedComponentWithType(tree, Child);
 
       child.props.updateUI({ name: 'b' });
       parent.props.updateUI({ name: 'a' });
@@ -82,8 +82,8 @@ describe('resetting UI state', () => {
     })(Child);
 
     const tree = render(<UIParent><FunctionalUIChild value='foo' /></UIParent>);
-    const parent = TestUtils.findRenderedComponentWithType(tree, Parent);
-    const child = TestUtils.findRenderedComponentWithType(tree, Child);
+    const parent = ReactTestUtils.findRenderedComponentWithType(tree, Parent);
+    const child = ReactTestUtils.findRenderedComponentWithType(tree, Child);
 
     assert.equal(child.props.ui.evaluated, 'foo');
     child.props.updateUI({ evaluated: 'next' });

--- a/test/ui/validation.js
+++ b/test/ui/validation.js
@@ -1,8 +1,8 @@
 'use strict';
 
-import { assert } from 'chai'; 
+import { assert } from 'chai';
 import React, { Component } from 'react';
-import TestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 import shallowEqual from 'react-redux/lib/utils/shallowEqual';
 
 import ui, { reducer } from '../../src';

--- a/test/utils/render.js
+++ b/test/utils/render.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { createStore, combineReducers } from 'redux';
 import ui, { reducer } from '../../src';
-import TestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 
 const store = createStore(combineReducers({ ui: reducer }));
 
@@ -18,7 +18,7 @@ const wrapWithProvider = (jsx) => (
 );
 
 const render = (jsx) => {
-  return TestUtils.renderIntoDocument(
+  return ReactTestUtils.renderIntoDocument(
     wrapWithProvider(jsx)
   );
 }
@@ -29,7 +29,7 @@ const renderAndFind = (jsx, type = null) => {
     jsx = <jsx />
   }
   const tree = render(jsx);
-  return TestUtils.findRenderedComponentWithType(tree, type);
+  return ReactTestUtils.findRenderedComponentWithType(tree, type);
 }
 
 export {


### PR DESCRIPTION
Fixes #69 
Small PR that fixes deprecation warnings caused by the removal of PropTypes in react v15.5.0

Deprecation information found here:
https://github.com/facebook/react/blob/master/CHANGELOG.md#1550-april-7-2017
> **15.5.0 (April 7, 2017)** Added a deprecation warning for React.PropTypes. Points users to prop-types instead. (@acdlite in 043845c)

I chose the react versions `^0.14.9 || ^15.3.0` because of compatibility information found on the prop-types README:

https://github.com/reactjs/prop-types/blob/master/README.md#compatibility
>This package is compatible with React 0.14.9. Compared to 0.14.8 (which was released a year ago), there are no other changes in 0.14.9, so it should be a painless upgrade.
>This package is compatible with React 15.3.0 and higher.

I realize that is a decent jump in minor patch versions, but I was able to get the tests to pass.

Also, you'll notice that I bumped the devDependency for react-dom quite significantly, and included the ReactTestUtils from react-dom package instead of the deprecated `react-addons-test-utils` https://www.npmjs.com/package/react-addons-test-utils

