### PR TITLE
Remove $(npm bin) as ./node_modules/.bin is on the path.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "UI state management for Redux and React",
   "main": "transpiled/index.js",
   "scripts": {
-    "prepublish": "$(npm bin)/babel -d transpiled src",
-    "test": "$(npm bin)/mocha  --compilers js:babel-register --recursive --require ./test/setup.js"
+    "prepublish": "babel -d transpiled src",
+    "test": "mocha  --compilers js:babel-register --recursive --require ./test/setup.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It also fixes running this on windows as $() inside npm scripts spawns a command
shell and not a bash shell so it fails the expansion.